### PR TITLE
Remove useOneOfDiscriminatorLookup

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -3,5 +3,4 @@ templateDir: /local/templates/
 additionalProperties:
   packageName: api
   enumClassPrefix: true
-  useOneOfDiscriminatorLookup: true
   disallowAdditionalPropertiesIfNotPresent: false


### PR DESCRIPTION
Causes certain objects to not be generated as nullable and then things break when the API actually returns null

ref https://github.com/goauthentik/authentik/issues/19878